### PR TITLE
Update dependency html-minifier to v3.5.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "browserify": "16.1.1",
     "fontify": "0.0.2",
-    "html-minifier": "3.5.8",
+    "html-minifier": "3.5.12",
     "nodemon": "1.17.2",
     "stylus": "0.54.5",
     "uglify-js": "3.3.16"


### PR DESCRIPTION
This Pull Request updates dependency [html-minifier](https://github.com/kangax/html-minifier) from `v3.5.8` to `v3.5.12`



<details>
<summary>Release Notes</summary>

### [`v3.5.9`](https://github.com/kangax/html-minifier/releases/v3.5.9)

##### Bug fixes
- fix corner cases in `collapseWhitespace` (#&#8203;878, #&#8203;883)
##### Improvements
- upgrade to `commander 2.14.1`

---

### [`v3.5.10`](https://github.com/kangax/html-minifier/releases/v3.5.10)

##### Bug fixes
- handle `ol` & `ul` as non-phrasing content (#&#8203;888, #&#8203;889)

---

### [`v3.5.11`](https://github.com/kangax/html-minifier/releases/v3.5.11)

##### Bug fixes
- allow disabling of default flags on CLI (#&#8203;860, #&#8203;892)

---

### [`v3.5.12`](https://github.com/kangax/html-minifier/releases/v3.5.12)

##### Bug fixes
- fix corner case in `decodeEntities` (#&#8203;893, #&#8203;894)

---

</details>


<details>
<summary>Commits</summary>

#### v3.5.9
-   [`a9a272c`](https://github.com/kangax/html-minifier/commit/a9a272c3e292aceaccf7db496e403bd7f4df8458) update online assets
-   [`51819e6`](https://github.com/kangax/html-minifier/commit/51819e6ac3f11ebfd5d8b7d36dd9ae2ebddc0813) fix corner cases in `collapseWhitespace` (#&#8203;883)
-   [`281f144`](https://github.com/kangax/html-minifier/commit/281f144247e57e3b0ee7f5d9ec2d9950b6a5c388) test minified asset
-   [`751f04c`](https://github.com/kangax/html-minifier/commit/751f04c612deddded030a3bddf2f3effbd8b59a7) update dependencies (#&#8203;884)
-   [`a7d7839`](https://github.com/kangax/html-minifier/commit/a7d78391b7f45252c320e1913e5901286f9cd30f) Version 3.5.9
#### v3.5.10
-   [`41c21c9`](https://github.com/kangax/html-minifier/commit/41c21c9b306040e5219f90eb502d0f3c65c47c7a) preserve whitespace around custom fragments within `&lt;pre&gt;` (#&#8203;885)
-   [`1de184e`](https://github.com/kangax/html-minifier/commit/1de184eb6c138fc83af5775242502c0b7a2e1eeb) Add &quot;ol&quot; and &quot;ul&quot; to nonPhrasing (#&#8203;889)
-   [`94ef1b6`](https://github.com/kangax/html-minifier/commit/94ef1b6f813696a4077b32c8cc0ba76fb39832c9) Version 3.5.10
#### v3.5.11
-   [`5de02ae`](https://github.com/kangax/html-minifier/commit/5de02ae86848226b93a49c72713aa4de85bffc00) Repackage with `clean-css@&#8203;4.1.11`
-   [`b685a05`](https://github.com/kangax/html-minifier/commit/b685a05340cfc10bb239297147ed425bd6e4ca6c) update dependencies
-   [`44700d2`](https://github.com/kangax/html-minifier/commit/44700d20b40e49ae74c294c981447c00bedc402e) test Node.js 8 instead of 7
-   [`416982e`](https://github.com/kangax/html-minifier/commit/416982efd0274769753607a227ee4dc577f39090) allow disabling of default flags on CLI (#&#8203;892)
-   [`6062467`](https://github.com/kangax/html-minifier/commit/6062467a800fac6d72aa56dd52612d40b9365860) Version 3.5.11
#### v3.5.12
-   [`68981b7`](https://github.com/kangax/html-minifier/commit/68981b79b53c232e834bf04341228a202c9e9bdc) fix corner case in `decodeEntities` (#&#8203;894)
-   [`1457840`](https://github.com/kangax/html-minifier/commit/14578402525ddb45fe3f35439a38d6a0d5c8e75a) Version 3.5.12

</details>