### PR TITLE
Update dependency nodemon to v1.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browserify": "15.2.0",
     "fontify": "0.0.2",
     "html-minifier": "3.5.8",
-    "nodemon": "1.14.11",
+    "nodemon": "1.17.2",
     "stylus": "0.54.5",
     "uglify-js": "3.3.8"
   },


### PR DESCRIPTION
This Pull Request updates dependency [nodemon](https://github.com/remy/nodemon) from `v1.14.11` to `v1.17.2`



<details>
<summary>Release Notes</summary>

### [`v1.14.12`](https://github.com/remy/nodemon/releases/v1.14.12)

##### Bug Fixes

* sniff for child.stdout before using it ([79e61f0](https://github.com/remy/nodemon/commit/79e61f0))
* wrongly normalizing slashes in windows ([33fa6f4](https://github.com/remy/nodemon/commit/33fa6f4)), closes [#&#8203;1236](`https://github.com/remy/nodemon/issues/1236`)

---

### [`v1.15.0`](https://github.com/remy/nodemon/releases/v1.15.0)

##### Features

* add support for `--spawn` ([#&#8203;1249](`https://github.com/remy/nodemon/issues/1249`)) ([5e88b04](https://github.com/remy/nodemon/commit/5e88b04)), closes [#&#8203;1245](`https://github.com/remy/nodemon/issues/1245`)

---

### [`v1.15.1`](https://github.com/remy/nodemon/releases/v1.15.1)

##### Bug Fixes

* ensure directories are watched, not files ([#&#8203;1260](`https://github.com/remy/nodemon/issues/1260`)) ([1cda8fa](https://github.com/remy/nodemon/commit/1cda8fa)), closes [#&#8203;1259](`https://github.com/remy/nodemon/issues/1259`)

---

### [`v1.17.0`](https://github.com/remy/nodemon/releases/v1.17.0)

##### Bug Fixes

* make it possible for windows to checkout ([#&#8203;1270](`https://github.com/remy/nodemon/issues/1270`)) ([0f39b2e](https://github.com/remy/nodemon/commit/0f39b2e)), closes [#&#8203;1255](`https://github.com/remy/nodemon/issues/1255`)
* windows exec resolution ([#&#8203;1274](`https://github.com/remy/nodemon/issues/1274`)) ([7ffd545](https://github.com/remy/nodemon/commit/7ffd545)), closes [#&#8203;1251](`https://github.com/remy/nodemon/issues/1251`)
* make clear where more opts are in help ([#&#8203;1271](`https://github.com/remy/nodemon/issues/1271`)) ([f4391d4](https://github.com/remy/nodemon/commit/f4391d4))
* put windows drive letter tweak in right place ([#&#8203;1272](`https://github.com/remy/nodemon/issues/1272`)) ([94b526f](https://github.com/remy/nodemon/commit/94b526f)), closes [#&#8203;1263](`https://github.com/remy/nodemon/issues/1263`)
##### Features

* try to resolve exec in node_modules/.bin ([#&#8203;1275](`https://github.com/remy/nodemon/issues/1275`)) ([7fb365d](https://github.com/remy/nodemon/commit/7fb365d)), closes [#&#8203;1268](`https://github.com/remy/nodemon/issues/1268`)
* feed args to exec when detecting script ([#&#8203;1273](`https://github.com/remy/nodemon/issues/1273`)) ([e41f3c3](https://github.com/remy/nodemon/commit/e41f3c3)), closes [#&#8203;1263](`https://github.com/remy/nodemon/issues/1263`)

_Note: due to an oddity in the automated build process, nodemon was bumped two minor versions instead of one. Nothing to worry about though._

---

### [`v1.17.1`](https://github.com/remy/nodemon/releases/v1.17.1)

##### Bug Fixes

* throwing exeception on run ([85ed19d](https://github.com/remy/nodemon/commit/85ed19d)), closes [#&#8203;1276](`https://github.com/remy/nodemon/issues/1276`)

---

### [`v1.17.2`](https://github.com/remy/nodemon/releases/v1.17.2)

##### Bug Fixes

* prevent throw when args missing ([#&#8203;1288](`https://github.com/remy/nodemon/issues/1288`)) ([89d6062](https://github.com/remy/nodemon/commit/89d6062)), closes [#&#8203;1286](`https://github.com/remy/nodemon/issues/1286`)
* watch count regression ([#&#8203;1287](`https://github.com/remy/nodemon/issues/1287`)) ([372e6b2](https://github.com/remy/nodemon/commit/372e6b2)), closes [#&#8203;1283](`https://github.com/remy/nodemon/issues/1283`)

---

</details>


<details>
<summary>Commits</summary>

#### v1.14.12
-   [`c9d8cd3`](https://github.com/remy/nodemon/commit/c9d8cd3bdd10891d365be6efd4c25ea991030651) chore: add oliver twist bot
-   [`66e0d13`](https://github.com/remy/nodemon/commit/66e0d133f52255b62d354579a77e601c74900059) chore: tweak oliver
-   [`4f0562a`](https://github.com/remy/nodemon/commit/4f0562a22d05a6c0db29691b40f1a936740511d4) chore: update oliver
-   [`79e61f0`](https://github.com/remy/nodemon/commit/79e61f00e77256893fc7cd453391e077cf29f356) fix: sniff for child.stdout before using it
-   [`4cfd0b9`](https://github.com/remy/nodemon/commit/4cfd0b9cf8f92aca1c8c75e5b041c0b3cd61cdff) chore: fix lint warning
-   [`33fa6f4`](https://github.com/remy/nodemon/commit/33fa6f4970412a6bfa12ff357f44dfebf0ad63c7) fix: wrongly normalizing slashes in windows
#### v1.15.0
-   [`b936f6c`](https://github.com/remy/nodemon/commit/b936f6ca9c23e7d98ff198c85620ca12f77950ab) docs: add mixmax sponsor ❤️
-   [`85475b5`](https://github.com/remy/nodemon/commit/85475b5b37ab3ca2d432a647ec3f36a60a2511f7) docs: typo
-   [`2918e0a`](https://github.com/remy/nodemon/commit/2918e0ae3e550e08c813018c3e1fbfb8fb628f6e) chore: bumping github image cache
-   [`913c34d`](https://github.com/remy/nodemon/commit/913c34d15a5cf05d52cf65792c2a0f2f106f2e70) docs: fix broken images
-   [`0e08ee2`](https://github.com/remy/nodemon/commit/0e08ee267fbf02828ef67c7cb98e233f3b807803) chore: update stalebot
-   [`5e88b04`](https://github.com/remy/nodemon/commit/5e88b04eaa94ba72a18fca7d28517a0316fe4cb3) feat: add support for `--spawn` (#&#8203;1249)
-   [`8895445`](https://github.com/remy/nodemon/commit/88954455becf55660f2d28e700d305ee7035f738)  fix: make watch &amp; ignore relative (#&#8203;1253)
-   [`70cfb7d`](https://github.com/remy/nodemon/commit/70cfb7dc232657e284ae3705fa76c5fd0054e298) chore: intentional bump of chokidar (#&#8203;1257)
#### v1.15.1
-   [`1cda8fa`](https://github.com/remy/nodemon/commit/1cda8fae4333f3e37c54d0923d99b9132fb6a010) fix: ensure directories are watched, not files (#&#8203;1260)
#### v1.16.0
-   [`f4391d4`](https://github.com/remy/nodemon/commit/f4391d4ff14fbd0811818bd6c7baa23ec9c6e90e) fix: make clear where more opts are in help (#&#8203;1271)
-   [`e41f3c3`](https://github.com/remy/nodemon/commit/e41f3c3aad148b3b283df1c579ff9e99071ff49d) feat: feed args to exec when detecting script (#&#8203;1273)
-   [`94b526f`](https://github.com/remy/nodemon/commit/94b526f80a067ab55f888a225339d7e23f797c64) fix: put windows drive letter tweak in right place (#&#8203;1272)
-   [`0f39b2e`](https://github.com/remy/nodemon/commit/0f39b2e34936599b5ddb83c4450e5cbf4f8eb9f9) fix: make it possible for windows to checkout (#&#8203;1270)
-   [`7ffd545`](https://github.com/remy/nodemon/commit/7ffd5454ed5397d0b2031c7eda97159c40da55fc) fix: windows exec resolution (#&#8203;1274)
-   [`7fb365d`](https://github.com/remy/nodemon/commit/7fb365d0cc6f6225c9b82af3bd64055b90ac3c8c) feat: try to resolve exec in node_modules/.bin (#&#8203;1275)
#### v1.17.1
-   [`85ed19d`](https://github.com/remy/nodemon/commit/85ed19d69a2117f7ca6cdf2aeb9cf5c5105a6c8b) fix: throwing exeception on run
#### v1.17.2
-   [`e16f2fe`](https://github.com/remy/nodemon/commit/e16f2fecf676d43fdf1a2905ecd9f6692ad99358) chore: revert package
-   [`41f0d42`](https://github.com/remy/nodemon/commit/41f0d421aa41544ab37e5f378697b289081c1012) chore: update issue template
-   [`8637e52`](https://github.com/remy/nodemon/commit/8637e52dd1d39c8755f1e621dda0ba9487e5f88f) chore: merge branch &#x27;master&#x27;
-   [`372e6b2`](https://github.com/remy/nodemon/commit/372e6b23fc4b437b510e80a2c171ebe38b59feeb) fix: watch count regression (#&#8203;1287)
-   [`89d6062`](https://github.com/remy/nodemon/commit/89d6062c687dce31f7878f3b7f427ed332e5cdd9) fix: prevent throw when args missing (#&#8203;1288)

</details>