### PR TITLE
Update dependency html-minifier to v3.5.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "browserify": "16.1.1",
     "fontify": "0.0.2",
-    "html-minifier": "3.5.12",
+    "html-minifier": "3.5.13",
     "nodemon": "1.17.2",
     "stylus": "0.54.5",
     "uglify-js": "3.3.16"


### PR DESCRIPTION
This Pull Request updates dependency [html-minifier](https://github.com/kangax/html-minifier) from `v3.5.12` to `v3.5.13`



<details>
<summary>Release Notes</summary>

### [`v3.5.13`](https://github.com/kangax/html-minifier/releases/v3.5.13)

##### Bug fixes
- fix race in QUnit web test (#&#8203;899)
##### Improvements
- reduce dependencies (#&#8203;898)

---

</details>


<details>
<summary>Commits</summary>

#### v3.5.13
-   [`f87dc20`](https://github.com/kangax/html-minifier/commit/f87dc202cbe592bfdcdd4b67b758d487f65bd354) reduce dependencies (#&#8203;898)
-   [`6f98d68`](https://github.com/kangax/html-minifier/commit/6f98d68739107ea5a25a9ef1bb72c0b02f627706) fix race in QUnit web test (#&#8203;899)
-   [`f8f7559`](https://github.com/kangax/html-minifier/commit/f8f755936be00dcb7f25cb7d46807cb9dd6e2880) Version 3.5.13

</details>