### PR TITLE
Update dependency nodemon to v1.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browserify": "16.1.1",
     "fontify": "0.0.2",
     "html-minifier": "3.5.13",
-    "nodemon": "1.17.2",
+    "nodemon": "1.17.3",
     "stylus": "0.54.5",
     "uglify-js": "3.3.16"
   },


### PR DESCRIPTION
This Pull Request updates dependency [nodemon](https://github.com/remy/nodemon) from `v1.17.2` to `v1.17.3`



<details>
<summary>Release Notes</summary>

### [`v1.17.3`](https://github.com/remy/nodemon/releases/v1.17.3)

##### Bug Fixes

* don't throw when required in the repl ([aa18c80](https://github.com/remy/nodemon/commit/aa18c80)), closes [#&#8203;1292](`https://github.com/remy/nodemon/issues/1292`)

---

</details>


<details>
<summary>Commits</summary>

#### v1.17.3
-   [`aa18c80`](https://github.com/remy/nodemon/commit/aa18c806b37715a5b13aa7660e098f1fe7319a1c) fix: don&#x27;t throw when required in the repl

</details>