### PR TITLE
Update dependency uglify-js to v3.3.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "html-minifier": "3.5.13",
     "nodemon": "1.17.3",
     "stylus": "0.54.5",
-    "uglify-js": "3.3.17"
+    "uglify-js": "3.3.18"
   },
   "dependencies": {
     "bootstrap": "4.0.0",


### PR DESCRIPTION
This Pull Request updates dependency [uglify-js](https://github.com/mishoo/UglifyJS2) from `v3.3.17` to `v3.3.18`



<details>
<summary>Release Notes</summary>

### [`v3.3.18`](https://github.com/mishoo/UglifyJS2/releases/v3.3.18)

&nbsp;

---

</details>


<details>
<summary>Commits</summary>

#### v3.3.18
-   [`02f47e1`](https://github.com/mishoo/UglifyJS2/commit/02f47e1713cb413ac0d2602039c18292f43db863) give sensible error against invalid input source map (#&#8203;3044)
-   [`8adfc29`](https://github.com/mishoo/UglifyJS2/commit/8adfc29f914efd2af62638491b6c3034e1cc8712) Don&#x27;t load source map until the JS source is fully received (#&#8203;3040)
-   [`fcf542f`](https://github.com/mishoo/UglifyJS2/commit/fcf542f262f73f45f13681f5af2745bea0898fb9) v3.3.18

</details>