### PR TITLE
Update dependency html-minifier to v3.5.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "browserify": "16.1.1",
     "fontify": "0.0.2",
-    "html-minifier": "3.5.13",
+    "html-minifier": "3.5.14",
     "nodemon": "1.17.3",
     "stylus": "0.54.5",
     "uglify-js": "3.3.18"


### PR DESCRIPTION
This Pull Request updates dependency [html-minifier](https://github.com/kangax/html-minifier) from `v3.5.13` to `v3.5.14`



<details>
<summary>Release Notes</summary>

### [`v3.5.14`](https://github.com/kangax/html-minifier/releases/v3.5.14)

##### Bug fixes
- preserve whitespace around `<ruby>` (#&#8203;904, #&#8203;905)

---

</details>


<details>
<summary>Commits</summary>

#### v3.5.14
-   [`e7bcf16`](https://github.com/kangax/html-minifier/commit/e7bcf1680f2e5b3c4fe232a2ffface1c7a481ad1) Preserve whitespace around inline &lt;ruby&gt; (#&#8203;905)
-   [`b714bd1`](https://github.com/kangax/html-minifier/commit/b714bd1f160ac187ea341ae636764b85ba8f2130) Version 3.5.14

</details>