### PR TITLE
Update dependency uglify-js to v3.3.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "html-minifier": "3.5.13",
     "nodemon": "1.17.3",
     "stylus": "0.54.5",
-    "uglify-js": "3.3.18"
+    "uglify-js": "3.3.20"
   },
   "dependencies": {
     "bootstrap": "4.0.0",


### PR DESCRIPTION
This Pull Request updates dependency [uglify-js](https://github.com/mishoo/UglifyJS2) from `v3.3.18` to `v3.3.20`



<details>
<summary>Release Notes</summary>

### [`v3.3.19`](https://github.com/mishoo/UglifyJS2/releases/v3.3.19)

&nbsp;

---

### [`v3.3.20`](https://github.com/mishoo/UglifyJS2/releases/v3.3.20)

&nbsp;

---

</details>


<details>
<summary>Commits</summary>

#### v3.3.19
-   [`e67553f`](https://github.com/mishoo/UglifyJS2/commit/e67553fa550ad355aa1946b5da5051434259a6ba) fix tree traversal on `AST_Do` (#&#8203;3047)
-   [`81603ec`](https://github.com/mishoo/UglifyJS2/commit/81603ecd156f494a6b0c02655c5361152711300d) improve performance through `makePredicate()` (#&#8203;3048)
-   [`b5bab25`](https://github.com/mishoo/UglifyJS2/commit/b5bab254ce2122a43e9ca0fdc757aecda7191576) speed up `has_parens()` (take 2) (#&#8203;3052)
-   [`44116c6`](https://github.com/mishoo/UglifyJS2/commit/44116c6d2bf80f08195f2a7568e80cc57113953f) fix AST corruption during `inline` of simple `return` (#&#8203;3056)
-   [`0b62a28`](https://github.com/mishoo/UglifyJS2/commit/0b62a28b476c443638d9894e14e4c29b2748143c) improve usability of `includeSources` (#&#8203;3057)
-   [`923deef`](https://github.com/mishoo/UglifyJS2/commit/923deeff35b708e49c4d8bcfa64dc53832cd4b5a) support inline source map from multiple files (#&#8203;3058)
-   [`db49daf`](https://github.com/mishoo/UglifyJS2/commit/db49daf365598986106c95def10e619e4e6ba4a0) mangle `Object.defineProperty()` (#&#8203;3059)
-   [`8d0b003`](https://github.com/mishoo/UglifyJS2/commit/8d0b00317e7f4ca63c806c2a6049bbbc804012d2) v3.3.19
#### v3.3.20
-   [`e5f6a88`](https://github.com/mishoo/UglifyJS2/commit/e5f6a882333cf0dcaf87e2a58dfa2867106114e9) fix corner case in reuse of `mangle` options (#&#8203;3062)
-   [`87857b0`](https://github.com/mishoo/UglifyJS2/commit/87857b0f1bcb428d36cf715d8ac218eebed6a3ff) v3.3.20

</details>