### PR TITLE
Update dependency browserify to v16.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "browserify": "16.1.1",
+    "browserify": "16.2.0",
     "fontify": "0.0.2",
     "html-minifier": "3.5.14",
     "nodemon": "1.17.3",


### PR DESCRIPTION
This Pull Request updates dependency [browserify](https://github.com/browserify/browserify) from `v16.1.1` to `v16.2.0`



<details>
<summary>Release Notes</summary>

### [`v16.2.0`](https://github.com/browserify/browserify/blob/master/CHANGELOG.md#&#8203;1620)

update the browser versions of `vm-browserify` and `string_decoder`.

`string_decoder` updates to the Node 8+ API.
`vm-browserify` replaces an unlicensed dependency by an MIT one.

`https://github.com/browserify/browserify/pull/1829`

---

</details>


<details>
<summary>Commits</summary>

#### v16.2.0
-   [`25c71db`](https://github.com/browserify/browserify/commit/25c71dbd9425b4a0aa811029d5a4b1d062d75395) 16.1.1
-   [`9345e21`](https://github.com/browserify/browserify/commit/9345e2186d98350b864afb730b9520684229a436) Update string_decoder and vm builtin modules
-   [`03ffac9`](https://github.com/browserify/browserify/commit/03ffac986cbbd71af000f5f4b6dee18ec27babd6) ci: Disable certificate check for very old npm
-   [`e333b14`](https://github.com/browserify/browserify/commit/e333b14752463dd5e1772b271994c02574500ed0) Merge pull request #&#8203;1827 from browserify/fix-cert
-   [`7005b6e`](https://github.com/browserify/browserify/commit/7005b6edcc7452ca589b17994b1ec143b430d42a) Merge pull request #&#8203;1829 from browserify/deps
-   [`00cc377`](https://github.com/browserify/browserify/commit/00cc377939e2434b321fd0c4253b882a6b5f1280) 16.2.0

</details>